### PR TITLE
Update Vercel adapter configuration to enable web analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -19,5 +19,9 @@ export default defineConfig({
     icon(),
   ],
 
-  adapter: vercel(),
+  adapter: vercel({
+    webAnalytics: {
+      enabled: true,
+    },
+  }),
 });


### PR DESCRIPTION
This pull request includes a small but important change to the `astro.config.mjs` file. The change enables web analytics for the Vercel adapter.

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL22-R26): Modified the Vercel adapter configuration to enable web analytics.